### PR TITLE
remove FunctionSource, simplifying design doc management, and forcing one-way serialization on functions

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const {BaseDTO, FunctionSource} = require('./src/base_dto')
+const BaseDTO = require('./src/base_dto')
 const Client = require('./src/client')
 const DatabaseAPI = require('./src/database_api')
 const {DesignDocDTO, ViewDTO} = require('./src/design_doc_dto')
@@ -10,7 +10,6 @@ module.exports = {
 	Client,
 	DatabaseAPI,
 	DesignDocDTO,
-	FunctionSource,
 	ViewDTO,
 	CouchUtils,
 }

--- a/src/client.js
+++ b/src/client.js
@@ -3,12 +3,12 @@ const SessionAPI = require('./session_api')
 
 class Client{
 	constructor(config){
-		this.config = config
-		let host = config.host || 'localhost'
-		let port = config.port || 5984
-		let protocol = config.protocol || 'http'
+		this.config = config || {}
+		let host = this.config.host || 'localhost'
+		let port = this.config.port || 5984
+		let protocol = this.config.protocol || 'http'
 		this.baseUrl = `${protocol}://${host}:${port}/`
-		this._session = new SessionAPI(this.baseUrl, config)
+		this._session = new SessionAPI(this.baseUrl, this.config)
 		this._databases = {}
 	}
 

--- a/src/database_api.js
+++ b/src/database_api.js
@@ -67,9 +67,14 @@ class DatabaseAPI{
 	}
 
 	readDoc(documentId){
+		// TODO: probably add a failIfDoesntExist option, currently if the document does not exist we return a fresh DTO
 		let path = `${this.databaseName}/${documentId}`
 		return this.session.makeRequest(path)
-			.then(json => new this.dtoClass(json))
+			.then(json => {
+				let doc = new this.dtoClass(json)
+				doc._id = doc._id || documentId
+				return doc
+			})
 	}
 
 	deleteDoc(dto){
@@ -101,15 +106,6 @@ class DatabaseAPI{
 			.then(response => {
 				return response['docs'].map(doc => new this.dtoClass(doc))
 			})
-	}
-
-	createDesignDoc(dto){
-		// TODO: assert dto is DesignDocDTO
-		let path = `${this.databaseName}/_design/${dto.name}`
-		let headers = {'Content-Type': 'application/json'}
-		let body = JSON.stringify(dto.toJSON())
-		return this.session.makeRequest(path, 'PUT', headers, body)
-			.then(json => DatabaseAPI._checkJSON(json, dto))
 	}
 
 	security(data){

--- a/src/design_doc_dto.js
+++ b/src/design_doc_dto.js
@@ -1,9 +1,8 @@
-const {BaseDTO, FunctionSource} = require('./base_dto')
+const BaseDTO = require('./base_dto')
 
 class ViewDTO extends BaseDTO{
 	static fields = [
-		{name: 'map', type: FunctionSource},
-		{name: 'reduce', type: FunctionSource}
+		'map', 'reduce'
 	]
 }
 
@@ -11,17 +10,25 @@ class DesignDocDTO extends BaseDTO{
 	static fields = [
 		'_id', '_rev', 'name', 'language', 'validate_doc_update',
 		{name: 'options', type: Object},
-		{name: 'filters', type: Object, subType: FunctionSource},
-		{name: 'lists', type: Object, subType: FunctionSource},
-		{name: 'rewrites', type: Array, subType: FunctionSource},
-		{name: 'shows', type: Object, subType: FunctionSource},
-		{name: 'updates', type: Object, subType: FunctionSource},
+		{name: 'filters', type: Object},
+		{name: 'lists', type: Object},
+		{name: 'rewrites', type: Array},
+		{name: 'shows', type: Object},
+		{name: 'updates', type: Object},
 		{name: 'views', type: Object, subType: ViewDTO}
 	]
 
+	addUpdate(name, updateFunction){
+		this.updates = this.updates || {}
+		this.updates[name] = updateFunction.toString()
+	}
+
 	addView(name, map, reduce){
 		this.views = this.views || {}
-		this.views[name] = new ViewDTO({map, reduce})
+		this.views[name] = new ViewDTO({
+			map: map ? map.toString() : map,
+			reduce: reduce ? reduce.toString() : reduce
+		})
 	}
 }
 

--- a/test/test_base_dto.js
+++ b/test/test_base_dto.js
@@ -1,4 +1,4 @@
-const {BaseDTO, FunctionSource} = require('../src/base_dto')
+const BaseDTO = require('../src/base_dto')
 
 describe('BaseDTO', () => {
 	class TestNestedDTO extends BaseDTO{
@@ -138,36 +138,5 @@ describe('BaseDTO', () => {
 				dto.fake_field = 'test'
 			}).toThrow(expected_error)
 		})
-	})
-})
-
-describe('FunctionSource', () => {
-	/* eslint-disable brace-style */
-	function testFunction(a, b){ return a+b }
-	/* eslint-disable brace-style */
-
-	let fnSource
-
-	class DTOWithFunctionSource extends BaseDTO{
-		static fields = [{name: 'callback', type: FunctionSource}]
-	}
-
-	it('should accept a function as an argument and store it as a string', () => {
-		fnSource = new FunctionSource(testFunction)
-		expect(fnSource.source).toEqual('function testFunction(a, b){ return a+b }')
-	})
-
-	it('should be able to convert the source string back into a function', () => {
-		let a = 10, b = 20, sum = 30
-		expect(testFunction(a, b)).toEqual(sum) // sanity check
-		expect(fnSource.toFunction()(a, b)).toEqual(testFunction(a, b))
-	})
-
-	it('should be compatible with BaseDTOs', () => {
-		let dto = new DTOWithFunctionSource()
-
-		dto.callback = testFunction
-
-		expect(dto.toJSON()).toEqual({callback: 'function testFunction(a, b){ return a+b }'})
 	})
 })

--- a/test/test_client.js
+++ b/test/test_client.js
@@ -1,6 +1,6 @@
 const Client = require('../src/client')
 const DatabaseAPI = require('../src/database_api')
-const {BaseDTO} = require('../src/base_dto')
+const BaseDTO = require('../src/base_dto')
 
 class TestDTO1 extends BaseDTO{
 	static databaseName = 'test_database_1'

--- a/test/test_database_api.js
+++ b/test/test_database_api.js
@@ -1,6 +1,6 @@
 const DatabaseAPI = require('../src/database_api')
 const SessionAPI = require('../src/session_api')
-const {BaseDTO} = require('../src/base_dto')
+const BaseDTO = require('../src/base_dto')
 
 describe('DatabaseAPI', () => {
 	class TestDTO extends BaseDTO{


### PR DESCRIPTION
This PR simplifies the way design document Javascript functions are serialized. Removing the ability to de-serialize them back into functions forces the user to keep configuration as code. Meaning the functions in CouchDB are never the source of truth.